### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ ECMobile
 
 [ECMobile](http://www.ecmobile.cn) 是基于 [ECShop](http://www.ecshop.com) 的手机商城客户端，包括iOS、Android、PHP三个平台源代码及框架已开放下载！
 
-#####支持开源及后续版本更新，请FORK和STAR，感谢您的支持！
+##### 支持开源及后续版本更新，请FORK和STAR，感谢您的支持！
 
 1. iOS: [https://github.com/GeekZooStudio/ECMobile_iOS](https://github.com/GeekZooStudio/ECMobile_iOS)
 2. Android: [https://github.com/GeekZooStudio/ECMobile_Android](https://github.com/GeekZooStudio/ECMobile_Android)

--- a/doc/ECMobile_3.2_PHP升级教程.md
+++ b/doc/ECMobile_3.2_PHP升级教程.md
@@ -1,4 +1,4 @@
-#ECMobile_3.2_PHP升级教程
+# ECMobile_3.2_PHP升级教程
 1.数据库中payment表添加微信支付
 		
 	INSERT INTO `d2c_payment` (`pay_id`, `pay_code`, `pay_name`, `pay_fee`, `pay_desc`, `pay_order`, `pay_config`, `enabled`, `is_cod`, `is_online`)

--- a/doc/ECMobile_PHP.md
+++ b/doc/ECMobile_PHP.md
@@ -1,4 +1,4 @@
-#目录结构
+# 目录结构
 
 <pre>
 ecmobile/controller		ECM控制器
@@ -7,7 +7,7 @@ ecmobile/payment		第三方支付
 ecmobile/test			测试用例
 </pre>
 
-#后台配置
+# 后台配置
 
 1. 下载源代码并解压
 2. 搜索源代码，将所有Your Information替换为您的网站信息
@@ -16,13 +16,13 @@ ecmobile/test			测试用例
 5. 尝试在浏览器中访问 `http://<您的网站>/ECMobile`，将看到欢迎信息。
 6. 接下来，您可以进行API测试。
 
-#客户端配置
+# 客户端配置
 
 1. 打开iOS/Android工程
 2. 根据文档将API URL替换为 http://<您的网站>/ECMobile/?url=
 3. 打包安装，并进行测试
 
-#联系方式
+# 联系方式
 
 官方论坛：http://bbs.ecmobile.cn/    
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
